### PR TITLE
Add linter to the generate_readme action

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -1,20 +1,28 @@
 name: Update README
+
 on:
   push:
     branches:
       - main
     paths:
       - '_README.md'
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Generate README.md
         run: |
           python3 generate_readme.py _README.md > README.md
+
+      - name: Lint README.md
+        run: npx awesome-lint README.md
+
       - name: Commit changes
+        if: success() # Only commit if linting passes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: 'Auto-update README.md [skip ci]'


### PR DESCRIPTION
## Types of Changes

> What types of changes does your PR introduce? Put an x in all boxes that apply

- [ ] New addition to list
- [ ] New category to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [x] Changing structure (organization) of list

---

## Proposed Changes

Updated the GitHub Action for generating the `README.md` to include the linter, ensuring only compliant files are committed to `main`.


---

## PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

---

## Further Comments

This change ensures that the `README.md` generated and committed to the `main` branch is always compliant with `awesome-lint` standards. 
