### PR TITLE
Add item: cli-anything-zotero

### DIFF
--- a/_README.md
+++ b/_README.md
@@ -94,6 +94,7 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 
 ### AI Integrations
 - [Aria](https://github.com/lifan0127/ai-research-assistant) - Aria is Your AI Research Assistant for zotero
+- [cli-anything-zotero](https://github.com/PiaoyangGuohai1/cli-anything-zotero) - Full-featured CLI for Zotero 7/8 with 40+ commands. Let AI agents (Claude Code, Cursor, Codex) manage your library through natural language — search, import, export, PDF, BibTeX, annotations, and more.
 - [Awesome GPT](https://github.com/MuiseDestiny/zotero-gpt) - Zotero plugin to provide GPT backend into Zotero using API.
 - [Beaver](https://github.com/jlegewie/beaver-zotero/) - Academic research assistant with native Zotero integration. Instantly searches through all your documents and explains complex concepts as you read.
 - [PapersGPT](https://github.com/papersgpt/papersgpt-for-zotero) - The Ultimate Zotero AI Plugin


### PR DESCRIPTION
## Add: cli-anything-zotero

**Category:** AI Integrations

**Entry:**

- [cli-anything-zotero](https://github.com/PiaoyangGuohai1/cli-anything-zotero) - Full-featured CLI for Zotero 7/8 with 40+ commands. Let AI agents (Claude Code, Cursor, Codex) manage your library through natural language — search, import, export, PDF, BibTeX, annotations, and more.

**Why this belongs here:**

This tool enables AI agents to directly manage Zotero libraries through a CLI interface. It goes beyond in-app AI chat plugins by providing 40+ structured commands that AI coding assistants can invoke — searching by keyword or full-text, importing by DOI/PMID, exporting BibTeX, attaching PDFs, managing annotations, and more. Includes a JS Bridge plugin for privileged Zotero operations.

- Apache 2.0 license
- Active maintenance
- Built on [CLI-Anything](https://github.com/HKUDS/CLI-Anything)
- Works with Zotero 7 and 8