### PR TITLE
Add item: Weavero

### DIFF
--- a/_README.md
+++ b/_README.md
@@ -41,6 +41,7 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 ### Customization
 - [Delitemwithatt](https://github.com/redleafnew/delitemwithatt) - Remove attachment(s) when deleting the item(s) or collection in Zotero and JurisM.
 - [Tara](https://github.com/l0o0/tara) - Zotero add-on for backup and restore preferences, add-ons, translators, styles, and locate between two machines.
+- [Weavero](https://github.com/mjthoraval/Weavero) - Clickable links in annotation comments and notes, plus a fast filter pane and items-tree columns.
 - [Zotero-actions-tags](https://github.com/windingwind/zotero-actions-tags) - Automatic tagging of items based on actions performed on them.
 - [Zotero-better-authors](https://github.com/github-young/zotero-better-authors) - Customize the display of author names in Zotero.
 - [Zotero-date-from-last-modified](https://github.com/retorquere/zotero-date-from-last-modified) - Shows when the item was last modified.


### PR DESCRIPTION
Adds [Weavero](https://github.com/mjthoraval/Weavero) under **Extensions → Customization** (inserted in alphabetical order, between *Tara* and *Zotero-actions-tags*).

> Clickable links in annotation comments and notes, plus a fast filter pane and items-tree columns.

Weavero is a Zotero 7+ plugin that turns URLs in annotation comments and notes into clickable links, and adds a filter popup, related-item plumbing, a tabs-menu overhaul, and items-tree columns on top of the standard library view. Active project with tagged GitHub releases (AGPL-3.0). Docs: the repo README.

Checklist:
- [x] Not a duplicate of an existing entry
- [x] Working documentation (README) for the description
- [x] Added in alphabetical order
- [x] Placed in an existing, appropriate category (Customization)
- [x] Edited `_README.md` only (`README.md` is auto-generated)
- [x] Separate PR for this one item; title formatted `Add item: Weavero`