### PR TITLE
Add item: MCP Server Zotero Dev

### DIFF
--- a/_README.md
+++ b/_README.md
@@ -53,6 +53,7 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 
 ### Developer
 - [Generator-zotero-plugin](https://www.npmjs.com/package/generator-zotero-plugin) - Generate a Zotero Plugin scaffold.
+- [MCP Server Zotero Dev](https://github.com/introfini/mcp-server-zotero-dev) - MCP server exposing a running Zotero over the Remote Debugging Protocol for AI-assisted plugin development (run JS, inspect DOM, read logs, hot-reload).
 - [Scaffold](https://www.zotero.org/support/dev/translators/scaffold) - An IDE for Zotero translators.
 
 ### File Management


### PR DESCRIPTION
Adds [MCP Server Zotero Dev](https://github.com/introfini/mcp-server-zotero-dev) by introfini under **Extensions → Developer** (alphabetical, between *Generator-zotero-plugin* and *Scaffold*).

> MCP server exposing a running Zotero over the Remote Debugging Protocol for AI-assisted plugin development (run JS, inspect DOM, read logs, hot-reload).

It pairs a Model Context Protocol server with a small bridge XPI so an AI assistant (Claude, etc.) can drive a live Zotero instance — execute privileged JS, read/write prefs, take screenshots, inspect the DOM, tail logs, and hot-reload plugins. Active project with tagged releases; the same author's `ZotSeek` is already listed under AI Integrations. (Developer felt like the better category since it's a plugin-development/debugging tool rather than a research-library integration, but AI Integrations would also fit — happy to move it.)

Checklist:
- [x] Not a duplicate of an existing entry
- [x] Working documentation (README) for the description
- [x] Added in alphabetical order
- [x] Placed in an existing, appropriate category (Developer)
- [x] Edited `_README.md` only (`README.md` is auto-generated)
- [x] Separate PR for this one item; title formatted `Add item: …`