### PR TITLE
Add item: zotero-marker

### DIFF
--- a/_README.md
+++ b/_README.md
@@ -35,6 +35,7 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 - [Zotero-citationcounts](https://github.com/eschnett/zotero-citationcounts) - Zotero plugin for auto-fetching citation counts from various sources.
 - [Zotero DOI Manager](https://github.com/bwiernik/zotero-shortdoi) - Zotero plugin to retrieve and manage DOIs for references.
 - [Zotero-inspire](https://github.com/fkguo/zotero-inspire) - Fetch publication information from INSPIRE-HEP and add it to Zotero.
+- [zotero-marker](https://github.com/lelelelelelelelelelelelele/zotero_marker) - Resolve the real publication venue, CORE/CCF tier, and citation count of arXiv preprints and write them back as proper metadata, so impact-factor / CCF / citation plugins recognize them.
 - [Zotero-pmcid-fetcher](https://github.com/retorquere/zotero-pmcid-fetcher) - Fetch PMCID/PMID for items with a DOI.
 - [Zotero TL;DR](https://github.com/syt2/Zotero-TLDR) - Zotero addon to automatically fetch TL;DR from Semantic Scholar for items.
 


### PR DESCRIPTION
Author here — I built this to fix my own Zotero library.

**Why:** In CS/ML most papers hit arXiv first; Zotero imports them as `preprint`, which has **no venue field** — so easyScholar / zotero-style / Citation Tally can't show CCF / impact factor / citation count for them, however cited.

**What it does:** keys on the arXiv id, resolves the real venue via Semantic Scholar (DBLP fallback for the many CS conferences with no Crossref DOI), converts `preprint` → `conferencePaper`/`journalArticle`, fills the venue fields, and writes the citation count to `Extra` — so those plugins light up normally. Deterministic (no LLM guessing); every change is shown in a table for review before writing. I use it on my own library.

Placement: Extensions → Citations, alphabetically between `Zotero-inspire` and `Zotero-pmcid-fetcher`; only `_README.md` edited (`README.md` is generated). Docs (EN + 中文): https://github.com/lelelelelelelelelelelelele/zotero_marker
