### PR TITLE
Add item: arxiv-marker

### DIFF
--- a/_README.md
+++ b/_README.md
@@ -26,6 +26,7 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 ## Extensions
 
 ### Citations
+- [arxiv-marker](https://github.com/lelelelelelelelelelelelele/arxiv-marker) - Resolve arXiv preprints to their real publication venue, CORE/CCF tier, and citation count, and write them back as proper metadata so citation / impact-factor plugins recognize them.
 - [Better BibTeX for Zotero](https://github.com/retorquere/zotero-better-bibtex) - Make Zotero effective for us LaTeX holdouts.
 - [cite-non-english](https://github.com/boan-anbo/cite-non-english) - Zotero extension to provide all-in-one support for non-English citations
 - [inciteful-zotero-plugin](https://github.com/inciteful-xyz/inciteful-zotero-plugin) - A Zotero plugin which integrates Inciteful.xyz.


### PR DESCRIPTION
<!--
MANDATORY: This pull request MUST follow this exact template. PRs missing required sections/checklists may be closed.
-->

## Types of Changes

> What types of changes does your PR introduce? Put an x in all boxes that apply

- [x] New addition to list
- [ ] New category to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

## Proposed Changes

### Why this change is needed

In CS/ML most papers hit arXiv first, and Zotero imports them as `preprint` — an item type with **no venue field**. As a result, venue/impact plugins such as easyScholar, zotero-style (Ethereal Style), and Citation Tally can't show the CCF/CORE tier, impact factor, or citation count for these items, no matter how heavily cited they are. arxiv-marker resolves the real publication venue of an arXiv preprint and writes it back as proper metadata so those plugins light up.

### Curation rationale

Documentation (bilingual README + screenshots): https://github.com/lelelelelelelelelelelelele/arxiv-marker

How it differs from existing entries:

- **vs `zotero-arxiv-workflow`** (closest sibling): that plugin handles the preprint↔published lifecycle by *merging* a preprint item with a separately-obtained published journal item (Zotero's built-in merge can't join different item types, which is why it exists). That needs (a) the published version to be found — unreliable, since old arXiv preprints may have no DOI shown— (b) maintaining a parent item plus two child items and two PDFs, and (c) downloading a new published entry first. arxiv-marker instead **switches the existing item's type in place** and fills venue/tier/citation — no second item, no merge, no new download. The two are complementary: arxiv-workflow manages PDFs/versions; arxiv-marker surfaces venue/tier/citation so impact plugins recognize the item.
- **vs `Zotero-citationcounts`** (same Citations category): fetches citation counts only — it doesn't resolve the venue/tier or change the item type.
- **vs `Zotero-inspire`** (same category): targets physics (INSPIRE-HEP); arxiv-marker targets CS/ML arXiv and its core action is the `preprint → conferencePaper/journalArticle` type conversion plus venue/CORE/CCF back-fill.

Maintenance/usefulness: released as v0.2.0 with a downloadable `.xpi` and an auto-update manifest; I use it on my own library.

### Tool quality

- **Release/maturity:** v0.2.0 published with `arxiv-marker-0.2.0.xpi` (one-click install, not a demo/placeholder) and an `update.json` auto-update manifest.
- **Platform:** native Zotero plugin; the manifest declares compatibility 7.0–10.x (Zotero 7/8/9 share the same bootstrapped plugin API). Developed and tested on Zotero 9.
- **Zotero-specific behavior:** keyed on the arXiv id, it resolves the real venue via Semantic Scholar (with a DBLP fallback for CS conferences that lack a Crossref DOI, matched by title + author + year), converts the item type from `preprint` to `conferencePaper`/`journalArticle`, fills the venue fields and DOI/ISSN, and writes the citation count into `Extra` (`Citations: N (SemanticScholar) [date]`) while preserving the arXiv id.
- **Design:** deterministic resolution (no LLM guessing); every proposed change is shown in a per-item review table and only written after I confirm.

**AI assistance — what I delegated vs. what I owned:**
- *Delegated to AI:* the implementation code — I directed an AI coding assistant to write it.
- *What I owned myself:* I designed the architecture and made every design decision — the deterministic, no-LLM resolution strategy; keying on the arXiv id with Semantic Scholar and a DBLP fallback for CS conferences without a Crossref DOI; converting the item type in place rather than merging a second item; and the per-item review table before any write. I reviewed the generated code and validated the result myself: the test suite passes, and I tested the plugin end-to-end on my own ~100-item Zotero library (major-conference, niche-venue, and unpublished cases) plus front-end/UI testing. I use it on my own library and maintain it.

**Data/privacy:** the tool only sends lookup identifiers off-device — arXiv ids to the Semantic Scholar API, and (only as a fallback when Semantic Scholar returns no venue) the paper title + first-author surname + year to DBLP. It reads public scholarly metadata only; it does not upload, sync, or store your Zotero library. All metadata changes are written locally in Zotero (the plugin needs no Zotero API key). An optional Semantic Scholar API key, if set, is stored locally and sent only as an auth header.


## PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added/updated necessary documentation (if appropriate)
- [x] I have added tests or a clear validation plan (manual checks, commands run)
- [x] I have explained why this item meets the curation bar for this list
- [x] I have confirmed the submitted project has working documentation
- [x] I have confirmed the submitted project is usable and not only a placeholder/demo repository
- [x] I have described the submitted project's Zotero-specific value

### AI-assisted contribution checklist

- [x] I used AI tooling where helpful, but this PR was reviewed and edited manually before submission.
- [x] The PR title/body and changelog text were written or substantially edited by a human contributor (not raw AI output).
- [x] If AI was used, I included what was delegated and what I validated myself.
- [x] If the submitted project used AI during development, it still has clear documentation, maintainer ownership, and evidence of usefulness.
- [x] If the submitted project is AI-assisted, it is not mostly unreviewed generated boilerplate or a low-effort vibe coded tool.
- [x] This PR is not low-effort (clear rationale, focused scope, and concrete verification).
- [x] I have confirmed this is not duplicate work (if fixing/adding items).

### Scope and quality checks

- [x] I am submitting one PR per unrelated item/intent.
- [x] New items are added in alphabetical order and in the correct category.
- [x] For list or category changes, `_README.md` is updated (README is generated).

## Proposed Verification

- [x] **Manual verification performed:** Installed the v0.2.0 `.xpi` in Zotero 9 and ran it across my ~100-item library, covering three cases: (a) preprints later published at major conferences, (b) preprints published at smaller/niche venues (the hard case for venue resolution), and (c) genuinely unpublished arXiv preprints. The tool correctly singled out the arXiv preprints, operated only on those, left every non-preprint and still-unpublished item untouched, and converted each resolved preprint to the corresponding `conferencePaper`/`journalArticle` with the right venue, CORE/CCF tier, and citation count.
- [x] **Automated tests/checks run:** All green. `pytest` covers the Python core (CLI, pipeline, Semantic Scholar/DBLP resolvers, CORE/CCF ranking, report, web API, Zotero adapter). A Node suite covers the plugin JS — `unit.mjs` (134 pass) and `scope.mjs` (10 pass; loads scripts exactly as Zotero's `loadSubScript` sandbox does). `parity.mjs` runs the plugin's JS resolver and the Python resolver on the same real arXiv ids against the live Semantic Scholar + DBLP APIs and diffs the output — 6/6 match on logic fields, 0 citation drift. Commands: `uv run pytest`; from `plugin/`: `node test/unit.mjs`, `node test/scope.mjs`, `node test/parity.mjs`.

## Further Comments

This is a fresh PR following the updated CONTRIBUTING template; it supersedes my earlier #49 (closed before the new guidelines landed). The project has since been renamed (zotero-marker → arxiv-marker). What I delegated to AI vs. validated myself is described above under Tool quality.