### PR TITLE
Add Causal Map for Zotero to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 
 
 ### Integrations
+- [Causal Map for Zotero](https://github.com/stevepowell99/causalmap-zotero) - - Send Zotero items to the Causal Map web app to build and analyse causal maps from your library.
+
+  ![Last Commit](https://img.shields.io/github/last-commit/stevepowell99/causalmap-zotero)
+![License](https://img.shields.io/github/license/stevepowell99/causalmap-zotero)
+![Issues](https://img.shields.io/github/issues/stevepowell99/causalmap-zotero)
+![Stars](https://img.shields.io/github/stars/stevepowell99/causalmap-zotero)
+![Forks](https://img.shields.io/github/forks/stevepowell99/causalmap-zotero)
+
 - [lyz](https://github.com/wshanks/lyz) - - Zotero plugin intended to make working with LyX/Zotero more pleasant.
 
   ![Last Commit](https://img.shields.io/github/last-commit/wshanks/lyz)


### PR DESCRIPTION
### Types of Changes
- Adding a new item to the list.

### Proposed Changes
**What and why:** Adds *Causal Map for Zotero* to the **Integrations** section. It is a Zotero 7 plugin that sends selected Zotero items to the [Causal Map](https://causalmap.app) web app, where users build and analyse causal maps and synthesise evidence from their library.

**Why it belongs in a curated Zotero list:** It is Zotero-specific functionality (a `.xpi` plugin that adds a menu action to Zotero items), not merely a general tool that happens to touch references. Docs and install instructions: https://github.com/stevepowell99/causalmap-zotero

**Project maturity / maintenance:** Actively maintained. Released through GitHub Releases with auto-update via the manifest `update_url`. Stable install URL: `https://github.com/stevepowell99/causalmap-zotero/releases/latest/download/causalmap-zotero.xpi`

### PR Checklist
- [x] I have read the contributing guidelines.
- [x] I have explained why this project belongs in the list.
- [x] The entry is added alphabetically within its section.
- [x] The project has working documentation.
- [x] The project provides Zotero-specific functionality, not only the general technology used.
- [x] This PR adds a single item.

### AI-assisted contribution
- [x] An AI tool was used to help draft this PR.
- [x] A human reviewed and verified the content; it is not raw AI output.
- [x] The PR has a clear rationale, focused scope, and concrete verification (working release and install URL).
