### PR TITLE
Add item: Zotero Metadata Hunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 ![Stars](https://img.shields.io/github/stars/bwiernik/zotero-shortdoi)
 ![Forks](https://img.shields.io/github/forks/bwiernik/zotero-shortdoi)
 
+- [Zotero Metadata Hunter](https://github.com/federicotorrielli/zotero-metadata-hunter) - - Finds missing DOIs and abstracts, replaces preprints with their published versions, and enriches sparse items with metadata from CrossRef, DBLP, Semantic Scholar, arXiv, PubMed, and OpenAlex.
+
+  ![Last Commit](https://img.shields.io/github/last-commit/federicotorrielli/zotero-metadata-hunter)
+![License](https://img.shields.io/github/license/federicotorrielli/zotero-metadata-hunter)
+![Issues](https://img.shields.io/github/issues/federicotorrielli/zotero-metadata-hunter)
+![Stars](https://img.shields.io/github/stars/federicotorrielli/zotero-metadata-hunter)
+![Forks](https://img.shields.io/github/forks/federicotorrielli/zotero-metadata-hunter)
+
 - [Zotero-inspire](https://github.com/fkguo/zotero-inspire) - - Fetch publication information from INSPIRE-HEP and add it to Zotero.
 
   ![Last Commit](https://img.shields.io/github/last-commit/fkguo/zotero-inspire)

--- a/README.md
+++ b/README.md
@@ -90,14 +90,6 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 ![Stars](https://img.shields.io/github/stars/bwiernik/zotero-shortdoi)
 ![Forks](https://img.shields.io/github/forks/bwiernik/zotero-shortdoi)
 
-- [Zotero Metadata Hunter](https://github.com/federicotorrielli/zotero-metadata-hunter) - - Finds missing DOIs and abstracts, replaces preprints with their published versions, and enriches sparse items with metadata from CrossRef, DBLP, Semantic Scholar, arXiv, PubMed, and OpenAlex.
-
-  ![Last Commit](https://img.shields.io/github/last-commit/federicotorrielli/zotero-metadata-hunter)
-![License](https://img.shields.io/github/license/federicotorrielli/zotero-metadata-hunter)
-![Issues](https://img.shields.io/github/issues/federicotorrielli/zotero-metadata-hunter)
-![Stars](https://img.shields.io/github/stars/federicotorrielli/zotero-metadata-hunter)
-![Forks](https://img.shields.io/github/forks/federicotorrielli/zotero-metadata-hunter)
-
 - [Zotero-inspire](https://github.com/fkguo/zotero-inspire) - - Fetch publication information from INSPIRE-HEP and add it to Zotero.
 
   ![Last Commit](https://img.shields.io/github/last-commit/fkguo/zotero-inspire)

--- a/_README.md
+++ b/_README.md
@@ -34,6 +34,7 @@ Your help is much appreciated. If you want to add something or fix a problem, lo
 - [Zotero-citation](https://github.com/MuiseDestiny/zotero-citation) - Make Zotero's citation in Word easier and clearer.
 - [Zotero-citationcounts](https://github.com/eschnett/zotero-citationcounts) - Zotero plugin for auto-fetching citation counts from various sources.
 - [Zotero DOI Manager](https://github.com/bwiernik/zotero-shortdoi) - Zotero plugin to retrieve and manage DOIs for references.
+- [Zotero Metadata Hunter](https://github.com/federicotorrielli/zotero-metadata-hunter) - Finds missing DOIs and abstracts, replaces preprints with their published versions, and enriches sparse items with metadata from CrossRef, DBLP, Semantic Scholar, arXiv, PubMed, and OpenAlex.
 - [Zotero-inspire](https://github.com/fkguo/zotero-inspire) - Fetch publication information from INSPIRE-HEP and add it to Zotero.
 - [Zotero-pmcid-fetcher](https://github.com/retorquere/zotero-pmcid-fetcher) - Fetch PMCID/PMID for items with a DOI.
 - [Zotero TL;DR](https://github.com/syt2/Zotero-TLDR) - Zotero addon to automatically fetch TL;DR from Semantic Scholar for items.


### PR DESCRIPTION
## Types of Changes
- [x] New addition to list

## Proposed Changes

### Why this change is needed
Adds Zotero Metadata Hunter, a plugin that finds missing DOIs and abstracts, upgrades preprints to their published versions, and enriches sparse imported items (e.g. Google Scholar BibTeX) with full metadata.

### Curation rationale
Placed under Citations, alongside other DOI-focused tools (Zotero DOI Manager, Zotero-pmcid-fetcher). Documentation is in the project README: https://github.com/federicotorrielli/zotero-metadata-hunter#readme
Difference from existing entries: Zotero DOI Manager only retrieves/manages DOIs. This plugin additionally checks preprints for a published version and re-parents attachments/notes onto the upgraded item, and enriches sparse existing items in place by merging fields from a canonical record. Actively maintained: 6 tagged releases from v0.4.0 to v0.5.0 (latest 2026-06-22), each built and published via GitHub Actions CI.

### Tool quality
Released and installable today via a signed .xpi from GitHub Releases; supports Zotero 7 and 8. Zotero-specific functionality: queries CrossRef, DBLP, Semantic Scholar, arXiv, PubMed, and OpenAlex; integrates with Zotero's own Translate.Search machinery (the same path used by "Add Item by Identifier"); adds toolbar/menu/keyboard-shortcut entry points and a preferences pane. AI was used during development; all code, architecture, and this list entry were reviewed and written by the maintainer (also the plugin's author). No unusual data/privacy implications: all lookups go through Zotero.HTTP.request() to public bibliographic APIs (CrossRef, DBLP, etc.), no third-party analytics or telemetry.

## PR Checklist
- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added/updated necessary documentation (if appropriate)
- [x] I have added tests or a clear validation plan (manual checks, commands run)
- [x] I have explained why this item meets the curation bar for this list
- [x] I have confirmed the submitted project has working documentation
- [x] I have confirmed the submitted project is usable and not only a placeholder/demo repository
- [x] I have described the submitted project's Zotero-specific value

### AI-assisted contribution checklist
- [x] I used AI tooling where helpful, but this PR was reviewed and edited manually before submission.
- [x] The PR title/body and changelog text were written or substantially edited by a human contributor (not raw AI output).
- [x] If AI was used, I included what was delegated and what I validated myself.
- [x] If the submitted project used AI during development, it still has clear documentation, maintainer ownership, and evidence of usefulness.
- [x] If the submitted project is AI-assisted, it is not mostly unreviewed generated boilerplate or a low-effort vibe coded tool.
- [x] This PR is not low-effort (clear rationale, focused scope, and concrete verification).
- [x] I have confirmed this is not duplicate work (if fixing/adding items).

### Scope and quality checks
- [x] I am submitting one PR per unrelated item/intent.
- [x] New items are added in alphabetical order and in the correct category.
- [x] For list or category changes, `_README.md` is updated (README is generated).

## Proposed Verification
- [x] Manual verification performed: ran `python3 generate_readme.py _README.md > README.md` to regenerate README.md per the repo's own workflow; confirmed the new entry sits alphabetically between "Zotero DOI Manager" and "Zotero-inspire"; confirmed no duplicate entry exists in the list; confirmed via `gh run list` that all 6 tagged releases (v0.4.0-v0.5.0) built successfully in CI and produced installable .xpi files.
- [ ] Automated tests/checks run: none configured for this list repo beyond the README generation script, which was run as above.

## Further Comments
AI assistance was used to draft this PR's boilerplate text against the required template; I reviewed and edited the rationale, verification steps, and entry description myself before submitting, as required by CONTRIBUTING.md.
